### PR TITLE
Improve the server to serve pages as HTTPS protocol #5

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -1,9 +1,18 @@
-http {
-  server {
-    listen 80;
+events {
+    worker_connections 1024;
+}
 
-    location / {
-      proxy_pass http://localhost:8000;
+http {
+    server {
+        listen 443 ssl;
+        ssl_certificate /etc/letsencrypt/live/idealog.store/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/idealog.store/privkey.pem; # managed by Certbot
+
+        location / {
+            proxy_pass http://web:8000;
+            proxy_set_header Host $host;                  # Preserve the original 'Host' header from the client request. Essential for applications such as Flask, Django, that rely on domain-based routing.
+            proxy_set_header X-Real-IP $remote_addr;      # Capture the original client's IP address. Useful when the server, doesn't know the client's acutal IP due to no direct connections to the client, needs to know it.
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # List of IP addresses the request has passed through. Important in multi-proxy environments to track the request's origin.
+        }
     }
-  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,14 @@ services:
       context: .
       dockerfile: Dockerfile.web
     command: gunicorn flask_server.app:app --bind 0.0.0.0:8000 # Launches the 'app' from the flask_server.app module with Gunicorn, accessible on all interfaces at port 8000.
-    depends_on:
-      - nginx
-    ports:
-      - "8000:8000"
 
   nginx:
     image: nginx:latest
     command: nginx -g "daemon off;" # Ensures NGINX runs in the foreground, keeping the container alive and responsive, by setting global directives.
+    depends_on:
+      - web
     volumes:
       - ./configs/nginx.conf:/etc/nginx/nginx.conf
+      - /etc/letsencrypt:/etc/letsencrypt
     ports:
-      - "80:80"
+      - "443:443"


### PR DESCRIPTION
Changelog
====
- Improves `configs/nginx.conf` to listen the port 443 & use ssl certificate to serve pages as HTTPS protocol
- Changes `./docker-compose.yml` to use port 443 to serve pages as HTTPS protocol
  - Removes the port property for the web service, to remove security risks.
  - Changes dependant relationships between the web & nginx service. Previously the web service depended on the nginx service mistakenly.