### PR TITLE
Introduce a new command that allows to create GitHub Projects cards in CLI #14

### DIFF
--- a/bin/command/gh-card
+++ b/bin/command/gh-card
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_PATH="$(cd "$(dirname "$0")"; pwd -P)"
+
+function usage() {
+  cat <<EOF
+Name:
+  $SCRIPT_NAME - A script to manage GitHub Projects cards.
+
+Description:
+  This script allows you to create GitHub Projects cards.
+
+Usage: $SCRIPT_NAME [OPTIONS] "New card name"
+
+Options:
+  -u, --update-id   Update GitHub Projects ID
+  -h, --help        Display this help message
+
+Examples:
+  $SCRIPT_NAME "New card name"                   # Create a new card with name "New card name"
+  $SCRIPT_NAME --update-id                       # Update GitHub Projects ID
+EOF
+}
+
+# check the number of arguments
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 1
+fi
+
+# check if gh is installed
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh is not installed."
+    echo "Please install gh using 'brew install gh' or 'apt install gh', run 'gh auth login' and try again."
+    exit 1
+fi
+
+function check_env_file() {
+  if [[ ! -f "$SCRIPT_PATH"/.env ]]; then
+    echo "The .env file does not exist. Please create it using '$SCRIPT_NAME --update-id' and try again."
+    exit 1
+  fi
+  source "$SCRIPT_PATH"/.env
+}
+
+function create_card() {
+  local query_str=$(printf 'mutation { addProjectV2DraftIssue(input: {projectId: "%s", title: "%s", body: ""}) { projectItem { id } } }' "$ProjectID" "$1")
+  gh api graphql -f query="$query_str" > /dev/null 2>&1
+
+  if [ $? -eq 0 ]; then
+    echo "Successfully created a new draft issue \"$1\" on the project's board."
+  fi
+}
+
+function update_id() {
+  echo "You are updating the GitHub Projects ID."
+  echo "WARN: If it is invalid, you can't use $SCRIPT_NAME anymore. Please ask the administrator for specific values to input before updating."
+
+  # ask the user if they have the specific values
+  read -p "Have you obtained the specific values from the administrator? (Y/n) " yn
+  [[ $yn =~ ^[Yy] ]] || { echo "Please contact the administrator to get the values."; exit 1; }
+
+  # read the values from the user
+  read -p "Input a new Project ID? " project_id
+
+  # save it to the .env file
+  echo "ProjectID=\"$project_id\"" > "$SCRIPT_PATH"/.env
+
+  echo "The content of a new env file: "
+  cat "$SCRIPT_PATH"/.env
+}
+
+# Parse options and arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -u|--update-id)
+      update_id
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *) # Default case: If no option, then it's the card name
+      check_env_file
+      create_card "$1"
+      shift
+      ;;
+  esac
+done

--- a/bin/command/one-time-setup
+++ b/bin/command/one-time-setup
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Get the path of the current directory
+SCRIPT_PATH="$(cd "$(dirname "$0")"; pwd -P)"
+
+# Check if the path is already in the bashrc
+if grep -q "${SCRIPT_PATH}" ~/.bashrc; then
+    exit 0
+fi
+
+# Add the directory bearalgorithm/command to ~/.bashrc. It enables to use the customized commands globally.
+echo "export PATH=\"\$PATH:${SCRIPT_PATH}\"" >> ~/.bashrc
+
+# Apply the change
+source ~/.bashrc


### PR DESCRIPTION
Changelog
====
- Introduces gh-card, a custom shell script command that allows to create GitHub Projects cards in CLI. This will help creating GitHub Projects cards easily.
- Introduces one-time-setup, a custom shell script command that adds `./bin/command` to `~/.bashrc`. This will help running gh-card globally.
