### PR TITLE
Introduce flask-server-setup that sets up the flask server with Google client ID & secret #18

### DIFF
--- a/bin/command/flask-server-setup
+++ b/bin/command/flask-server-setup
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SCRIPT_PATH="$(cd "$(dirname "$0")"; pwd -P)"
+ENV_PATH="$SCRIPT_PATH/../../flask_server/.env"
+
+if [[ -f $ENV_PATH ]]; then
+    sudo rm -f $ENV_PATH
+fi
+touch $ENV_PATH
+
+read -p "Input a new GOOGLE_OAUTH_CLIENT_ID? " GOOGLE_OAUTH_CLIENT_ID
+read -p "Input a new GOOGLE_OAUTH_CLIENT_SECRET? " GOOGLE_OAUTH_CLIENT_SECRET
+
+echo "GOOGLE_OAUTH_CLIENT_ID=$GOOGLE_OAUTH_CLIENT_ID" >> $ENV_PATH
+echo "GOOGLE_OAUTH_CLIENT_SECRET=$GOOGLE_OAUTH_CLIENT_SECRET" >> $ENV_PATH
+
+FLASK_SECRET_KEY=$(openssl rand -hex 32)
+echo "FLASK_SECRET_KEY=$FLASK_SECRET_KEY" >> $ENV_PATH
+
+echo "SQLALCHEMY_DATABASE_URI=/app/database/db.sqlite" >> $ENV_PATH
+
+echo "The content of a new env file for the flask server: "
+cat "$ENV_PATH"

--- a/bin/command/one-time-setup
+++ b/bin/command/one-time-setup
@@ -13,3 +13,5 @@ echo "export PATH=\"\$PATH:${SCRIPT_PATH}\"" >> ~/.bashrc
 
 # Apply the change
 source ~/.bashrc
+
+echo "Please run flask-server-setup to setup the flask server."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       context: .
       dockerfile: Dockerfile.web
     command: gunicorn flask_server.app:app --bind 0.0.0.0:8000  --access-logfile - --error-logfile - # Launches the 'app' from the flask_server.app module with Gunicorn, accessible on all interfaces at port 8000.
+    volumes:
+      - ./database:/app/database
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
Changelog
====
- Introduces a custom command named `flask-server-setup` that sets up the flask server with Google client ID & secret.
- Adds `- ./database:/app/database` in volume property of web service in `docker-compose.yml`. I decided to use `./database` directory for the database file but this path should be added to `docker-compose.yml` if the db file should keep its content even if the container is terminated.