### PR TITLE
Correct the incorrect return format in models.py #38

### DIFF
--- a/flask_server/models.py
+++ b/flask_server/models.py
@@ -99,7 +99,7 @@ def write_message(message, written_date, category_id, msg_id, user_id):
     except Exception as e:
         db.session.rollback()
         print(f"Error occurred: {e}")
-        return f"Operation failed: {e}", 500
+        return False
 
 def update_category(name, category_id, user_id):
     try:
@@ -114,6 +114,7 @@ def update_category(name, category_id, user_id):
         return True
     except Exception as e:
         db.session.rollback()
+        print(f"Error occurred: {e}")
         return False
 
 def fetch_messages(target, limit, parent_msg_id, target_date, category_id, user_id):

--- a/flask_server/routes.py
+++ b/flask_server/routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, current_app, jsonify, redirect, request, send_from_directory, session, url_for
 from flask_server import models
+from urllib.parse import unquote
 import requests
 
 blueprint = Blueprint('main', __name__)
@@ -37,19 +38,23 @@ def fetch_categories():
 
 @blueprint_api.route('/write_message')
 def write_message():
-    message = request.args.get('message', default='')
+    message = unquote(request.args.get('message', default=''))
     written_date = request.args.get('written_date', default='')
     category_id = request.args.get('category_id', default='')
     msg_id = request.args.get('msg_id', default='')
 
-    return models.write_message(message, written_date, category_id, msg_id, session.get('profile')['id'])
+    if models.write_message(message, written_date, category_id, msg_id, session.get('profile')['id']):
+        return jsonify(success=True)
+    return jsonify(success=False)
 
 @blueprint_api.route('/update_category')
 def update_category():
-    name = request.args.get('name', default='')
+    name = unquote(request.args.get('name', default=''))
     category_id = request.args.get('id', default='')
 
-    return models.update_category(name, category_id, session.get('profile')['id'])
+    if models.update_category(name, category_id, session.get('profile')['id']):
+        return jsonify(success=True)
+    return jsonify(success=False)
 
 @blueprint_api.route('/fetch_messages')
 def fetch_messages():

--- a/web_client/src/content.js
+++ b/web_client/src/content.js
@@ -328,5 +328,5 @@ msg_id !== null 인 케이스에 관한 구현.
     }
 }
 
-api.category_id = window.parent.content_category_id;
+api.category_id = localStorage.getItem('content_category_id');
 new Content(document.querySelector("main"));

--- a/web_client/src/main.js
+++ b/web_client/src/main.js
@@ -86,7 +86,7 @@ class Title{
             this.categories = response;
             const allCategory = this.categories.find(category => category.name === "All");
             if (allCategory) {
-                content_category_id = allCategory.id;
+                localStorage.setItem('content_category_id', allCategory.id);
                 document.querySelector("iframe").src = "/components/content.html";
             }
             const noneCategory = this.categories.find(category => category.name === "None");
@@ -120,7 +120,7 @@ class Title{
 
     move_category(category_id)
     {
-        content_category_id = category_id;
+        localStorage.setItem('content_category_id', category_id);
         document.querySelector("iframe").src = "/components/content.html"; 
     }
 
@@ -292,7 +292,7 @@ class Textarea {
     }
 }
 
-let content_category_id, user_none_category_id; // will be used in content.js, called as `window.parent.content_category_id`.
+let user_none_category_id;
 window.onload = async ()=>{
     new Title(document.querySelector("main > div.title"));
     new Textarea(document.querySelector("main > div.textarea"));


### PR DESCRIPTION
Changelog
====
- Corrects the incorrect return format in models.py and routes.py, since flask needs a precise return format.
- Adds a missing error message logging code in models.py
- Fixes the query parsing code in models.py to unquote the message. Some messages are sent after encoded but the previous code didn't unquote it, so the unquoted messages were stored to the db.
- Uses localStorage to store the current category ID for content.html. Previously it used `window.parent` to check the current category ID but it doesn't work. 