### PR TITLE
Trigger the workflow when a new PR is open #53

### DIFF
--- a/.github/workflows/check_diff_format.yml
+++ b/.github/workflows/check_diff_format.yml
@@ -3,6 +3,7 @@ name: Check Formatting & Type Hints on Diff
 on:
   pull_request:
     types:
+      - opened
       - synchronize
 
 jobs:


### PR DESCRIPTION
Changelog
====
- Triggers the workflow when a new PR is open. Previously it didn't trigger since it didn't contain `opened` in the trigger condition in the workflow.