### PR TITLE
Fix bugs in the workflow file #55

### DIFF
--- a/.github/workflows/check_diff_format.yml
+++ b/.github/workflows/check_diff_format.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 2  # Fetch the last two commits to get diff
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -23,19 +21,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint mypy ypaf
+        pip install pylint mypy yapf
         pip install --no-cache-dir -r flask_server/requirements-base.txt
         sudo apt-get install -y shfmt
 
     - name: Check Format on Diff
       run: bin/command/check-diff-format HEAD~1
-
-    - name: Check Type Hints on Diff for Python codes
-      run: |
-        FILES=$(git diff --name-only HEAD~1 HEAD | grep '\.py$')
-    
-        if [ ! -z "$FILES" ]; then
-          mypy $FILES
-        else
-          echo "No Python files were changed."
-        fi

--- a/bin/command/check-diff-format
+++ b/bin/command/check-diff-format
@@ -54,3 +54,9 @@ for file in $PYTHON_FILES; do
     # Remove the temporary pylint report
     rm -f "$pylint_report"
 done
+
+# Check the python files using mypy
+if [ ! -z "$PYTHON_FILES" ]; then
+    echo "Checking the python files with mypy..."
+    mypy $PYTHON_FILES
+fi


### PR DESCRIPTION
Changelog
====
- Fix typo in the workflow file. It should be `yapf` but it was `ypaf`
- Remove the code about mypy in the workflow file and moves it to check-diff-format. Due to unknown reasons, it seems impossible to use git diff in the workflow file.