### PR TITLE
Fix bug in the workflow file that fetches the recent commits #63

### DIFF
--- a/.github/workflows/check_diff_format.yml
+++ b/.github/workflows/check_diff_format.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
Changelog
====
- Fix bug in the workflow file that fetches the recent commits. Previously it cloned only the latest commit but it doesn't work since the workflow uses `git diff HEAD~1` which needs at least the latest two commits.