### PR TITLE
Verify if the user is authenticated before processing the API request #67

### DIFF
--- a/flask_server/app.py
+++ b/flask_server/app.py
@@ -25,6 +25,8 @@ def create_app():
     flask_app = Flask(__name__,
                       static_url_path='',
                       static_folder=STATIC_FOLDER)
+    flask_app.config[
+        'SESSION_COOKIE_SECURE'] = True  # allow HTTPS only for session cookie
     flask_app.secret_key = config('FLASK_SECRET_KEY')
     flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app, x_proto=1)
     flask_app.google_oauth = OAuth(flask_app).register(

--- a/flask_server/blueprints/api/views.py
+++ b/flask_server/blueprints/api/views.py
@@ -11,6 +11,19 @@ blueprint_api = Blueprint('api', __name__)
 ALLOWED_PROPERTIES_API_PROFILE = {'name'}
 
 
+@blueprint_api.before_request
+def verify_authentication():
+    """
+    Verify if the user is authenticated before processing the request.
+
+    Returns:
+    - Response: JSON message
+    """
+    if 'profile' not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+    return None
+
+
 @blueprint_api.route('/profile')
 def handle_api_profile():
     """

--- a/flask_server/blueprints/auth/views.py
+++ b/flask_server/blueprints/auth/views.py
@@ -34,6 +34,12 @@ def authorized():
     Returns:
     - Response: The redirect object
     """
+
+    if 'state' not in session or 'state' not in request.args or session[
+            'state'] != request.args['state']:
+        # Invalid state, possibly due to CSRF
+        return "Invalid state parameter", 400
+
     is_guest = request.args.get('guest', default=False, type=bool)
 
     if is_guest:
@@ -61,7 +67,8 @@ def user_join():
     if action:
         return handle_join_action(action)
 
-    return send_from_directory(current_app.static_folder, 'src/pages/join.html')
+    return send_from_directory(current_app.static_folder,
+                               'src/pages/join.html')
 
 
 def handle_join_action(action=None):


### PR DESCRIPTION
Changelog
====
- Verifies if the user is authenticated before processing the API request, by adding a function `verify_authentication` into `flask_server/blueprints/api/views.py`. Previously it didn't, so anyone could post messages without any authentications.
- allows HTTPS only for session cookie. Previously it allowed HTTP for session cookie but this is vulnerable to MITM attacks.
- checks if the session or req args have `state` before processing `/login/callback` API request. This is to prevent CSRF attack.