### PR TITLE
Address broken test issue #79

### DIFF
--- a/.github/workflows/check_diff_format.yml
+++ b/.github/workflows/check_diff_format.yml
@@ -29,3 +29,14 @@ jobs:
 
     - name: Check Format on Diff
       run: bin/command/check-diff-format HEAD~1
+
+    - name: Run pytest
+      run: |
+        FLASK_SECRET_KEY=$(openssl rand -hex 32)
+        echo "FLASK_SECRET_KEY=$FLASK_SECRET_KEY" >>flask_server/.env
+        echo "SQLALCHEMY_DATABASE_URI=/app/database/db.sqlite" >>flask_server/.env
+        sudo mkdir database
+        sudo chmod 777 database
+        sudo touch database/db.sqlite
+        sudo chmod 777 database/db.sqlite
+        sudo docker-compose up --build pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,11 @@ services:
     ports:
       - "80:80"
       - "443:443"
+
+  pytest:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    command: pytest
+    volumes:
+      - ./database:/app/database

--- a/flask_server/app.py
+++ b/flask_server/app.py
@@ -8,7 +8,6 @@ from authlib.integrations.flask_client import OAuth
 from decouple import config
 
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS
 from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_server import models
@@ -33,7 +32,6 @@ def create_app(is_test: bool = False):
         CORS(flask_app,
              origins=[config('DOMAIN_NAME')
                       ])  # allow requests only from the configured domain name
-        flask_app.secret_key = config('FLASK_SECRET_KEY')
         flask_app.wsgi_app = ProxyFix(  # type: ignore
             flask_app.wsgi_app, x_proto=1)
         flask_app.google_oauth = OAuth(flask_app).register(  # type: ignore
@@ -48,6 +46,7 @@ def create_app(is_test: bool = False):
             redirect_to='authorized',
             client_kwargs={'scope': 'profile email'},
         )
+    flask_app.secret_key = config('FLASK_SECRET_KEY')
     flask_app.register_blueprint(blueprint, url_prefix='')
     flask_app.register_blueprint(blueprint_auth, url_prefix='/auth')
     flask_app.register_blueprint(blueprint_api, url_prefix='/api')
@@ -65,6 +64,7 @@ def create_app(is_test: bool = False):
     return flask_app
 
 
+app = create_app()
+
 if __name__ == '__main__':
-    app = create_app()
     app.run(host='0.0.0.0', debug=True)


### PR DESCRIPTION
Changelog
====
- Addresses broken test issue by running `flask_app.secret_key = config('FLASK_SECRET_KEY')` even when in the test mode.
- Adds `Run pytest` to the CI pipeline.
- Moves `app = create_app()` to the main code block of `flask_server/app.py` since the previous code didn't work properly when running the server.
- Introduces a new service named `pytest` to `docker-compose.yml`, in order to use it just for the test.