### PR TITLE
Implement API gateways deployment via gcloud builds #85

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo docker-compose up --build
 2. 현재 디렉토리 내 파일들을 현재 GCP 프로젝트로 배포
 
 ```bash
-gcloud builds submit --config cloudbuild.yaml .
+gcloud builds submit --config cloudbuild.yaml . --substitutions=_TIMESTAMP=$(date +%s)
 ```
 
 

--- a/api-config.yaml
+++ b/api-config.yaml
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info:
+  title: "hello_world_api"
+  description: "API for the hello_world_function"
+  version: "1.0.0"
+host: "REGION-PROJECT_ID.cloudfunctions.net"
+schemes:
+  - "https"
+paths:
+  /api/hello_world:
+    get:
+      summary: "Invoke the hello_world_function"
+      operationId: "hello"
+      x-google-backend:
+        address: "https://REGION-PROJECT_ID.cloudfunctions.net/hello_world_function"
+      responses:
+        '200':
+          description: "Successful response"

--- a/bin/setup-new-gcp-project.sh
+++ b/bin/setup-new-gcp-project.sh
@@ -7,18 +7,23 @@ fi
 
 gcloud auth login
 
+PROJECT_ID=$1
+
 SCRIPT_PATH="$(
     cd "$(dirname "$0")"
     pwd -P
 )"
-TIMESTAMP=$(date +%s)
-PROJECT_ID="my-project-$TIMESTAMP"
-PROJECT_NAME="MyProject$TIMESTAMP"
-PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
-echo "PROJECT_ID=\"$PROJECT_ID\"" >"$SCRIPT_PATH"/.env
+
+if [ -z "$PROJECT_ID" ]; then
+    SCRIPT_NAME=$(basename "$0")
+    echo "No PROJECT_ID provided. Usage: ./$SCRIPT_NAME <PROJECT_ID>"
+    exit 1
+fi
+
+sed -i "s/_PROJECT_ID: .*/_PROJECT_ID: '$PROJECT_ID'/" "$SCRIPT_PATH"/../cloudbuild.yaml
 
 echo "Creating new project: $PROJECT_ID"
-gcloud projects create $PROJECT_ID --name="$PROJECT_NAME"
+gcloud projects create $PROJECT_ID --name=Project-"$PROJECT_ID"
 
 echo "Setting the project ID to $PROJECT_ID..."
 gcloud config set project $PROJECT_ID
@@ -26,9 +31,11 @@ gcloud config set project $PROJECT_ID
 echo "Enabling necessary APIs..."
 gcloud services enable cloudfunctions.googleapis.com
 gcloud services enable cloudresourcemanager.googleapis.com
+gcloud services enable apigateway.googleapis.com
 
 echo "Adding necessary roles to each service account..."
-gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com --role=roles/cloudfunctions.admin
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
+gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com --role=roles/apigateway.admin
 gcloud iam service-accounts add-iam-policy-binding $PROJECT_ID@appspot.gserviceaccount.com --member=serviceAccount:$PROJECT_NUMBER@cloudbuild.gserviceaccount.com --role=roles/iam.serviceAccountUser
 
 echo "APIs are successfully enabled and project is set."

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,19 +1,35 @@
-env_variables:
-  REGION: 'asia-northeast3'
-  FUNCTION_NAME: 'hello_world_function'
+substitutions:
+  _REGION: 'asia-northeast3'
+  _PROJECT_ID: 'red-girder-405405'
+  _TIMESTAMP: ''
 
 steps:
-  # read PROJECT_ID from .env
-  - name: 'bash'
-    args: ['if [ -f bin/.env ]; then source bin/.env && gcloud config set project $PROJECT_ID; fi']
-    entrypoint: '/bin/sh'
-
-  # deploy
+  # update project setting and api-config.yaml
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: ['functions', 'deploy', '$FUNCTION_NAME', '--runtime', 'python39', '--trigger-http', '--entry-point', 'hello_world', '--source', './gcp_cloud_functions/hello_world', '--region', '$REGION']
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |
+        gcloud config set project $_PROJECT_ID
 
-  # set permissions
+  # deploy Cloud Functions
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: ['functions', 'add-iam-policy-binding', '$FUNCTION_NAME', '--region', '$REGION', '--member', 'allUsers', '--role', 'roles/cloudfunctions.invoker']
+    args: ['functions', 'deploy', 'hello_world_function', '--runtime', 'python39', '--trigger-http', '--entry-point', 'hello_world', '--source', './gcp_cloud_functions/hello_world', '--region', '$_REGION']
+
+  # create API Gateways and deploy
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |
+        gcloud api-gateway apis create hello-world-api || true
+
+        sed -i 's/REGION-PROJECT_ID/${_REGION}-${_PROJECT_ID}/g' api-config.yaml
+        gcloud api-gateway api-configs create hello-world-api-config-"${_TIMESTAMP}" --api=hello-world-api --openapi-spec=api-config.yaml --backend-auth-service-account=${_PROJECT_ID}@appspot.gserviceaccount.com || true
+
+        gcloud api-gateway gateways create hello-world-gateway --api=hello-world-api --api-config=hello-world-api-config-"${_TIMESTAMP}" --location=us-central1 \
+          || gcloud api-gateway gateways update hello-world-gateway --api-config=hello-world-api-config-"${_TIMESTAMP}"
+
+        gcloud api-gateway gateways describe hello-world-gateway --location=us-central1
 
 timeout: '1600s'


### PR DESCRIPTION
Changelog
====
- Updates cloudbuild.yaml to have implementations for API gateways deployment
- Updates bin/setup-new-gcp-project.sh to use a single parameter for PROJECT_ID
- Introduces api-config.yaml for API gateways deployment automations
